### PR TITLE
Added ability to save image for lesson in Cloudinary | OC-69

### DIFF
--- a/src/course/course.module.ts
+++ b/src/course/course.module.ts
@@ -1,5 +1,5 @@
 import { Module } from '@nestjs/common';
-import { CloudinaryModule } from '../cloudinary/cloudinary.module';
+import { CloudinaryService } from '../cloudinary/cloudinary.service';
 import { ImageService } from '../image/image.service';
 import { LoggerModule } from '../logger/logger.module';
 import { PrismaService } from '../prisma/prisma.service';
@@ -11,7 +11,7 @@ import {
 } from './services';
 
 @Module({
-  imports: [LoggerModule, CloudinaryModule],
+  imports: [LoggerModule],
   controllers: [CourseController],
   providers: [
     CourseAllUsersService,
@@ -19,6 +19,7 @@ import {
     CourseSellerService,
     PrismaService,
     ImageService,
+    CloudinaryService,
   ],
 })
 export class CourseModule {}

--- a/src/lesson/lesson.controller.ts
+++ b/src/lesson/lesson.controller.ts
@@ -9,10 +9,14 @@ import {
   Patch,
   Post,
   Req,
+  UploadedFile,
   UseGuards,
+  UseInterceptors,
 } from '@nestjs/common';
+import { FileInterceptor } from '@nestjs/platform-express';
 import { Request } from 'express';
 import { AuthGuard } from '../auth/auth.guard';
+import { imageUploadOptions } from '../utils';
 import { CreateLessonDto, UpdateLessonDto } from './dto';
 import { LessonService } from './lesson.service';
 
@@ -29,12 +33,19 @@ export class LessonController {
   @Post('module/:moduleId')
   @HttpCode(HttpStatus.CREATED)
   @UseGuards(AuthGuard)
+  @UseInterceptors(FileInterceptor('image', imageUploadOptions))
   create(
     @Req() req: Request,
     @Param('moduleId') moduleId: string,
     @Body() createLessonDto: CreateLessonDto,
+    @UploadedFile() image: Express.Multer.File,
   ) {
-    return this.lessonService.create(moduleId, req.user.id, createLessonDto);
+    return this.lessonService.create(
+      moduleId,
+      req.user.id,
+      createLessonDto,
+      image,
+    );
   }
 
   @Get(':id')
@@ -45,12 +56,14 @@ export class LessonController {
 
   @Patch(':id')
   @UseGuards(AuthGuard)
+  @UseInterceptors(FileInterceptor('image', imageUploadOptions))
   update(
     @Req() req: Request,
     @Param('id') id: string,
     @Body() updateLessonDto: UpdateLessonDto,
+    @UploadedFile() image: Express.Multer.File,
   ) {
-    return this.lessonService.update(id, req.user.id, updateLessonDto);
+    return this.lessonService.update(id, req.user.id, updateLessonDto, image);
   }
 
   @Delete(':id')

--- a/src/lesson/lesson.module.ts
+++ b/src/lesson/lesson.module.ts
@@ -1,4 +1,6 @@
 import { Module } from '@nestjs/common';
+import { CloudinaryService } from '../cloudinary/cloudinary.service';
+import { ImageService } from '../image/image.service';
 import { LoggerModule } from '../logger/logger.module';
 import { PrismaService } from '../prisma/prisma.service';
 import { LessonController } from './lesson.controller';
@@ -7,6 +9,6 @@ import { LessonService } from './lesson.service';
 @Module({
   imports: [LoggerModule],
   controllers: [LessonController],
-  providers: [LessonService, PrismaService],
+  providers: [LessonService, PrismaService, ImageService, CloudinaryService],
 })
 export class LessonModule {}

--- a/src/module/module.module.ts
+++ b/src/module/module.module.ts
@@ -1,4 +1,6 @@
 import { Module } from '@nestjs/common';
+import { CloudinaryService } from '../cloudinary/cloudinary.service';
+import { ImageService } from '../image/image.service';
 import { LoggerModule } from '../logger/logger.module';
 import { PrismaService } from '../prisma/prisma.service';
 import { ModuleController } from './module.controller';
@@ -7,6 +9,6 @@ import { ModuleService } from './module.service';
 @Module({
   imports: [LoggerModule],
   controllers: [ModuleController],
-  providers: [ModuleService, PrismaService],
+  providers: [ModuleService, PrismaService, ImageService, CloudinaryService],
 })
 export class ModuleModule {}


### PR DESCRIPTION
lesson creation:
If the image comes in by url, it's just saved in the database. If the image comes as a file, it is saved in Cloudinary and its url and publicId are saved in the database.

lesson editing:
if an image comes in by url, the imageUrl is replaced with the new url and the imagePublicId is deleted if a file arrives, the old image is deleted from Cloudinary and the new image is saved there and its imageUrl and imagePublicId are saved in the database. if the isRemoveImage field arrives, the image is cleared from Cloudinary and all fields for the course image are also cleared in the database.