### PR TITLE
Changed adding points to the seller | OC-88

### DIFF
--- a/src/points/points.service.ts
+++ b/src/points/points.service.ts
@@ -30,7 +30,6 @@ export class PointsService {
             some: {
               id: courseId,
               userId,
-              isDeployed: false,
             },
           },
         },


### PR DESCRIPTION
Now when a course is deployed to the blockchain,
20 points will always be awarded,
regardless of whether the course has been deployed or not